### PR TITLE
Добавил системные переменные окружения в конфиг

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,8 @@
+import os
 from dotenv import dotenv_values
 
 
-config = dotenv_values(".env")
+config = {**dotenv_values(".env"), **os.environ}
 
 # Create .env file in the same directory and add BOT_API_TOKEN variable there to use bot
 BOT_API_TOKEN = config.get("BOT_API_TOKEN")


### PR DESCRIPTION
dotenv_values(".env") берет значения исключительно из файла, игнорируя переменные окружения. Это может быть неудобно при развертывании в Docker, так как передать файл при запуске контейнера нельзя, а переменную среды -- можно, поэтому код был изменен так, что объявленная переменная среды закроет собой переменную из .env файла.